### PR TITLE
Feature/up

### DIFF
--- a/src/main/java/project/academyshow/controller/LikeController.java
+++ b/src/main/java/project/academyshow/controller/LikeController.java
@@ -1,0 +1,25 @@
+package project.academyshow.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import project.academyshow.controller.request.UpRequest;
+import project.academyshow.controller.response.ApiResponse;
+import project.academyshow.security.entity.CustomUserDetails;
+import project.academyshow.service.LikeService;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeService likeService;
+
+    /** 좋아요를 클릭하거나 클릭 해제 한다 */
+    @PostMapping("/up")
+    public ApiResponse<?> createOrDestroy(@AuthenticationPrincipal CustomUserDetails user,
+                                          @RequestBody UpRequest request) {
+        likeService.createOrDestroy(request, user);
+        return ApiResponse.SUCCESS_NO_DATA_RESPONSE;
+    }
+}

--- a/src/main/java/project/academyshow/controller/request/ReviewRequest.java
+++ b/src/main/java/project/academyshow/controller/request/ReviewRequest.java
@@ -3,6 +3,7 @@ package project.academyshow.controller.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.academyshow.entity.Member;
+import project.academyshow.entity.ReferenceType;
 import project.academyshow.entity.Review;
 
 
@@ -13,7 +14,7 @@ public class ReviewRequest {
     private Integer rating;
     private String reviewAge;
 
-    public Review toEntity(Review.TYPE type, Member member, Long reviewedId) {
+    public Review toEntity(ReferenceType type, Member member, Long reviewedId) {
         return Review.builder()
                 .type(type)
                 .reviewedId(reviewedId)

--- a/src/main/java/project/academyshow/controller/request/UpRequest.java
+++ b/src/main/java/project/academyshow/controller/request/UpRequest.java
@@ -1,0 +1,22 @@
+package project.academyshow.controller.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.academyshow.entity.Up;
+import project.academyshow.entity.Member;
+import project.academyshow.entity.ReferenceType;
+
+@Getter
+@NoArgsConstructor
+public class UpRequest {
+    private ReferenceType type;
+    private Long referenceId;
+
+    public Up toEntity(Member member) {
+        return Up.builder()
+                .type(type)
+                .referenceId(referenceId)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/project/academyshow/controller/response/AcademyResponse.java
+++ b/src/main/java/project/academyshow/controller/response/AcademyResponse.java
@@ -20,8 +20,9 @@ public class AcademyResponse {
     private List<String> subjects;
     private List<String> educations;
     private boolean shuttle;
+    private ReferenceUpStatistics upStatistics;
 
-    public AcademyResponse(Academy academy) {
+    public AcademyResponse(Academy academy, ReferenceUpStatistics upStatistics) {
         id = academy.getId();
         name = academy.getName();
         profile = academy.getProfile();
@@ -32,5 +33,10 @@ public class AcademyResponse {
         subjects = Arrays.stream(academy.getSubjects().split(",")).collect(Collectors.toList());
         educations = Arrays.stream(academy.getEducations().split(",")).collect(Collectors.toList());
         shuttle = academy.isShuttle();
+        this.upStatistics = upStatistics;
+    }
+
+    public static AcademyResponse of(Academy academy, ReferenceUpStatistics upStatistics) {
+        return new AcademyResponse(academy, upStatistics);
     }
 }

--- a/src/main/java/project/academyshow/controller/response/ApiResponse.java
+++ b/src/main/java/project/academyshow/controller/response/ApiResponse.java
@@ -14,6 +14,10 @@ public class ApiResponse<T> {
     public static final ApiResponse DELETE_SUCCESS_RESPONSE =
             new ApiResponse(200, "삭제에 성공했습니다", null);
 
+    public static final ApiResponse SUCCESS_NO_DATA_RESPONSE =
+            new ApiResponse(200, "성공했씁니다.", null);
+
+
     public ApiResponse(int code, String msg, T data) {
         if (data != null)
             this.count = data instanceof List ? ((List<?>) data).size() : 1;

--- a/src/main/java/project/academyshow/controller/response/ReferenceUpStatistics.java
+++ b/src/main/java/project/academyshow/controller/response/ReferenceUpStatistics.java
@@ -1,0 +1,25 @@
+package project.academyshow.controller.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReferenceUpStatistics {
+    private enum STATUS  {
+        NOT_LOGIN, YES, NO
+    }
+
+    private Long count;
+    private STATUS status;    /** 좋아요 상태*/
+
+    public static ReferenceUpStatistics of(long count, boolean isLike) {
+
+        return new ReferenceUpStatistics(count, isLike ? STATUS.YES:STATUS.NO);
+    }
+
+    public static ReferenceUpStatistics notAuthenticatedof(long count) {
+        return new ReferenceUpStatistics(count, STATUS.NOT_LOGIN);
+    }
+}

--- a/src/main/java/project/academyshow/controller/response/ReviewResponse.java
+++ b/src/main/java/project/academyshow/controller/response/ReviewResponse.java
@@ -1,13 +1,14 @@
 package project.academyshow.controller.response;
 
 import lombok.Getter;
+import project.academyshow.entity.ReferenceType;
 import project.academyshow.entity.Review;
 
 @Getter
 public class ReviewResponse extends AbstractAcademyshowResponse{
     private final Long id;
     private final Long reviewedId;
-    private final Review.TYPE type;
+    private final ReferenceType type;
     private final String name;
     private final String profile;
     private final String comment;

--- a/src/main/java/project/academyshow/entity/ReferenceType.java
+++ b/src/main/java/project/academyshow/entity/ReferenceType.java
@@ -1,0 +1,5 @@
+package project.academyshow.entity;
+
+public enum ReferenceType {
+    ACADEMY, TUTOR
+}

--- a/src/main/java/project/academyshow/entity/Review.java
+++ b/src/main/java/project/academyshow/entity/Review.java
@@ -12,16 +12,12 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Review extends AbstractTimestampEntity {
-    public enum TYPE {
-        ACADEMY, TUTOR
-    }
-
     @Id
     @GeneratedValue
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    private TYPE type;
+    private ReferenceType type;
 
     @Column
     private Long reviewedId;

--- a/src/main/java/project/academyshow/entity/Up.java
+++ b/src/main/java/project/academyshow/entity/Up.java
@@ -1,0 +1,28 @@
+package project.academyshow.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Up extends AbstractTimestampEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ReferenceType type;
+
+    /** component likes are added */
+    @Column
+    private Long referenceId;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/project/academyshow/repository/LikeRepository.java
+++ b/src/main/java/project/academyshow/repository/LikeRepository.java
@@ -1,0 +1,14 @@
+package project.academyshow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.academyshow.entity.Up;
+import project.academyshow.entity.Member;
+import project.academyshow.entity.ReferenceType;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Up, Long> {
+    Optional<Up> findByTypeAndReferenceIdAndMember(ReferenceType type, Long referenceId, Member member);
+
+    Long countByTypeAndReferenceId(ReferenceType type, Long referenceId);
+}

--- a/src/main/java/project/academyshow/repository/ReviewRepository.java
+++ b/src/main/java/project/academyshow/repository/ReviewRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import project.academyshow.entity.ReferenceType;
 import project.academyshow.entity.Review;
 
 import javax.persistence.Tuple;
@@ -23,7 +24,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
                      "where r.type = :type " +
                      "and r.reviewedId = :reviewedId "
     )
-    Page<Review> findAllByTypeEqualsAndReviewedIdEquals(Pageable pageable, Review.TYPE type, Long reviewedId);
+    Page<Review> findAllByTypeEqualsAndReviewedIdEquals(Pageable pageable, ReferenceType type, Long reviewedId);
 
     @Override
     @Query("select r from Review r inner join fetch r.member where r.id = :id")
@@ -34,5 +35,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "where r.type = :type " +
             "and r.reviewedId = :id " +
             "group by r.rating ")
-    List<Tuple> countGroupByRatingForType(Review.TYPE type, Long id);
+    List<Tuple> countGroupByRatingForType(ReferenceType type, Long id);
 }

--- a/src/main/java/project/academyshow/service/AcademyService.java
+++ b/src/main/java/project/academyshow/service/AcademyService.java
@@ -8,7 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import project.academyshow.controller.request.SearchRequest;
 import project.academyshow.controller.response.ReviewStatistics;
 import project.academyshow.entity.Academy;
-import project.academyshow.entity.Review;
+import project.academyshow.entity.ReferenceType;
+
 import project.academyshow.repository.AcademyRepository;
 import project.academyshow.repository.ReviewRepository;
 
@@ -33,7 +34,7 @@ public class AcademyService {
     }
 
     public ReviewStatistics reviewStatistics(Long id) {
-        List<Tuple> tuples = reviewRepository.countGroupByRatingForType(Review.TYPE.ACADEMY, id);
+        List<Tuple> tuples = reviewRepository.countGroupByRatingForType(ReferenceType.ACADEMY, id);
         return new ReviewStatistics(tuples);
     }
 }

--- a/src/main/java/project/academyshow/service/LikeService.java
+++ b/src/main/java/project/academyshow/service/LikeService.java
@@ -1,0 +1,54 @@
+package project.academyshow.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.academyshow.controller.request.UpRequest;
+import project.academyshow.controller.response.ReferenceUpStatistics;
+import project.academyshow.entity.Up;
+
+import project.academyshow.entity.Member;
+import project.academyshow.entity.ReferenceType;
+import project.academyshow.repository.LikeRepository;
+import project.academyshow.security.entity.CustomUserDetails;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public void createOrDestroy(UpRequest request, CustomUserDetails userDetails) {
+        Optional<Up> like = getLikeByComponentAndMember(request.getType(),
+                                                          request.getReferenceId(),
+                                                          userDetails.getMember());
+        if(like.isPresent())
+            likeRepository.delete(like.get());
+        else
+            likeRepository.save(request.toEntity(userDetails.getMember()));
+    }
+
+    public ReferenceUpStatistics getLikeInfoByReference(ReferenceType type, Long componentId, CustomUserDetails userDetails) {
+        if(Objects.isNull(userDetails))
+            return ReferenceUpStatistics.notAuthenticatedof(likeCountByReference(type, componentId));
+
+        return ReferenceUpStatistics.of(likeCountByReference(type, componentId),
+                               isLikeClicked(type, componentId, userDetails));
+    }
+
+    private Long likeCountByReference(ReferenceType type, Long componentId) {
+        return likeRepository.countByTypeAndReferenceId(type, componentId);
+    }
+
+    private boolean isLikeClicked(ReferenceType type, Long componentId, CustomUserDetails userDetails) {
+        return getLikeByComponentAndMember(type, componentId, userDetails.getMember()).isPresent();
+    }
+
+    private Optional<Up> getLikeByComponentAndMember(ReferenceType type, Long componentId, Member member) {
+        return likeRepository.findByTypeAndReferenceIdAndMember(type, componentId, member);
+    }
+}

--- a/src/main/java/project/academyshow/service/ReviewService.java
+++ b/src/main/java/project/academyshow/service/ReviewService.java
@@ -6,20 +6,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestMapping;
 import project.academyshow.controller.request.ReviewRequest;
 import project.academyshow.controller.response.ReviewResponse;
 import project.academyshow.entity.Member;
+import project.academyshow.entity.ReferenceType;
 import project.academyshow.entity.Review;
 import project.academyshow.repository.ReviewRepository;
 import project.academyshow.security.AuthUtil;
 
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ReviewService {
+
     private final ReviewRepository reviewRepository;
     private final MemberService memberService;
 
@@ -27,12 +27,12 @@ public class ReviewService {
         return toResponseDtoPage(reviewRepository.findAll(pageable));
     }
 
-    public Page<ReviewResponse> findAll(Pageable pageable, Review.TYPE type, Long reviewedId) {
+    public Page<ReviewResponse> findAll(Pageable pageable, ReferenceType type, Long reviewedId) {
         return toResponseDtoPage(
                 reviewRepository.findAllByTypeEqualsAndReviewedIdEquals(pageable, type, reviewedId));
     }
 
-    public ReviewResponse create(ReviewRequest request, Review.TYPE type, Long reviewedId) {
+    public ReviewResponse create(ReviewRequest request, ReferenceType type, Long reviewedId) {
         Member member = AuthUtil.getLoggedInMember();
         return ReviewResponse.of(reviewRepository.save(request.toEntity(type, member, reviewedId)));
     }


### PR DESCRIPTION
## 개요
1. 단일 테이블전략을 위해 ReferenceType ENUM 생성
2. 좋아요 기능 구현 (생성, 삭제)
3. 학원 단일 데이터 응답에 좋아요 갯수 추가 (학원 리스트 응답에는 추가예정)

## 설명
api/up 으로 요청을 보내면  ReferenceType(학원, 과외...)과 ReferenceId(학원, 과외 ID) 에 매칭되는 객체에 좋아요를 생성하거나 삭제 한다.

api 요청은 로그인시만 가능하고, 좋아요가 없으면 생성하고, 좋아요가 있으면 삭제하도록 구현했다.