### PR TITLE
BatchLikes 도입 및 배치작업, 스케줄러 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/project/academyshow/AcademyShowApplication.java
+++ b/src/main/java/project/academyshow/AcademyShowApplication.java
@@ -1,9 +1,13 @@
 package project.academyshow;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableBatchProcessing
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class AcademyShowApplication {
@@ -11,5 +15,4 @@ public class AcademyShowApplication {
     public static void main(String[] args) {
         SpringApplication.run(AcademyShowApplication.class, args);
     }
-
 }

--- a/src/main/java/project/academyshow/config/BatchLikesConfig.java
+++ b/src/main/java/project/academyshow/config/BatchLikesConfig.java
@@ -1,0 +1,133 @@
+package project.academyshow.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import project.academyshow.entity.BatchLikes;
+
+import javax.persistence.EntityManagerFactory;
+
+/**
+ * 참고자료
+ * https://khj93.tistory.com/entry/Spring-Batch%EB%9E%80-%EC%9D%B4%ED%95%B4%ED%95%98%EA%B3%A0-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
+ *
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class BatchLikesConfig {
+    
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final EntityManagerFactory entityManagerFactory;
+
+    /**
+     * batchLike 들의 Count를 초기화한후
+     * batchLike 들의 Count 다시 센다.
+     */
+    @Bean
+    public Job BatchLikesJob() throws Exception {
+
+        Job exampleJob = jobBuilderFactory.get("batchLikesJob")
+                .start(batchLikeCountInitStep())
+                .next(batchLikeCountStep())
+                .build();
+
+        return exampleJob;
+    }
+
+    /**
+     * batchLikeCountInitStep
+     * batchLike 를 천개씩 가지고 와서 0으로 초기화시킨다.
+     */
+    @Bean
+    @JobScope
+    public Step batchLikeCountInitStep() throws Exception {
+        return stepBuilderFactory.get("Step")
+                .startLimit(2)
+                .<BatchLikes, BatchLikes>chunk(1000)
+                .reader(readerForInit())
+                .processor(processorForInit())
+                .writer(writer())
+                .build();
+    }
+
+
+    @Bean
+    @JobScope
+    public Step batchLikeCountStep() throws Exception {
+        return stepBuilderFactory.get("Step")
+                .startLimit(2)
+                .<BatchLikes, BatchLikes>chunk(1000)
+                .reader(readerForCount())
+                .processor(processorForCount())
+                .writer(writer())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<BatchLikes> readerForInit() throws Exception {
+        return new JpaPagingItemReaderBuilder<BatchLikes>()
+                .pageSize(1000)
+                .queryString("select b FROM BatchLikes b ORDER BY b.id ASC")
+                .entityManagerFactory(entityManagerFactory)
+                .name("batchLikeInitializer")
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemProcessor<BatchLikes, BatchLikes> processorForInit(){
+        return new ItemProcessor<BatchLikes, BatchLikes>() {
+            @Override
+            public BatchLikes process(BatchLikes b) throws Exception {
+                b.resetCountForBatch();
+                return b;
+            }
+        };
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<BatchLikes> readerForCount() throws Exception {
+        return new JpaPagingItemReaderBuilder<BatchLikes>()
+                .pageSize(1000)
+                .queryString("select l.batchLikes FROM Likes l ORDER BY l.id ASC")
+                .entityManagerFactory(entityManagerFactory)
+                .name("JpaPagingItemReader")
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemProcessor<BatchLikes, BatchLikes> processorForCount(){
+        return new ItemProcessor<BatchLikes, BatchLikes>() {
+            @Override
+            public BatchLikes process(BatchLikes b) throws Exception {
+                b.incrementCountForBatch();
+                return b;
+            }
+        };
+    }
+
+    @Bean
+    @StepScope
+    public JpaItemWriter<BatchLikes> writer(){
+        return new JpaItemWriterBuilder<BatchLikes>()
+                .entityManagerFactory(entityManagerFactory)
+                .build();
+    }
+}

--- a/src/main/java/project/academyshow/config/BatchLikesScheduler.java
+++ b/src/main/java/project/academyshow/config/BatchLikesScheduler.java
@@ -1,0 +1,38 @@
+package project.academyshow.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class BatchLikesScheduler {
+
+    private final JobLauncher jobLauncher;
+
+    private final BatchLikesConfig batchLikesConfig;
+
+    @Scheduled(fixedDelay = 1000*3600*24)
+    public void runJob() {
+        log.info("좋아요 배치작업 시작");
+        Map<String, JobParameter> confMap = new HashMap<>();
+        confMap.put("time", new JobParameter(System.currentTimeMillis()));
+        JobParameters parameters = new JobParameters(confMap);
+
+        try {
+            jobLauncher.run(batchLikesConfig.BatchLikesJob(), parameters);
+            log.info("좋아요 배치작업 성공");
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            log.info("좋아요 배치작업 실패!");
+        }
+    }
+}

--- a/src/main/java/project/academyshow/dev/database/DbInit.java
+++ b/src/main/java/project/academyshow/dev/database/DbInit.java
@@ -309,6 +309,7 @@ public class DbInit {
                     .build();
 
             em.persist(post);
+            em.persist(BatchLikes.of(post));
         }
 
         private void createUp(ReferenceType type, Long referenceId, Member member) {
@@ -357,6 +358,7 @@ public class DbInit {
                     .build();
 
             em.persist(tutorInfo);
+            em.persist(BatchLikes.of(tutorInfo));
         }
 
         private void createAcademy(Member member, String[] academyInfo) {
@@ -377,6 +379,7 @@ public class DbInit {
                     .build();
 
             em.persist(academy);
+            em.persist(BatchLikes.of(academy));
             academies.add(academy);
         }
 

--- a/src/main/java/project/academyshow/entity/Academy.java
+++ b/src/main/java/project/academyshow/entity/Academy.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Builder
@@ -42,4 +43,11 @@ public class Academy {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "academy", fetch = FetchType.LAZY)
+    private List<BatchLikes> batchLikes;
+
+    public BatchLikes getBatchLikes() {
+        return batchLikes.get(0);
+    }
 }

--- a/src/main/java/project/academyshow/entity/BatchLikes.java
+++ b/src/main/java/project/academyshow/entity/BatchLikes.java
@@ -1,0 +1,61 @@
+package project.academyshow.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+public class BatchLikes {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column
+    private Long count = 0L;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academy_id")
+    private Academy academy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tutor_info_id")
+    private TutorInfo tutorInfo;
+
+    public void resetCountForBatch() {
+        this.count = 0L;
+    }
+
+    public void incrementCountForBatch() {
+        this.count += 1L;
+    }
+
+    /**
+     * batchlikes creator
+     */
+    public static BatchLikes of(Post post) {
+        return BatchLikes.builder()
+                .post(post)
+                .build();
+    }
+
+    public static BatchLikes of(Academy academy) {
+        return BatchLikes.builder()
+                .academy(academy)
+                .build();
+    }
+
+    public static BatchLikes of(TutorInfo tutorInfo) {
+        return BatchLikes.builder()
+                .tutorInfo(tutorInfo)
+                .build();
+    }
+}

--- a/src/main/java/project/academyshow/entity/Likes.java
+++ b/src/main/java/project/academyshow/entity/Likes.java
@@ -22,6 +22,10 @@ public class Likes {
     private Member member;
 
     @ManyToOne
+    @JoinColumn(name = "batch_likes_id")
+    private BatchLikes batchLikes;
+
+    @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
 
@@ -40,6 +44,7 @@ public class Likes {
         return Likes.builder()
                 .member(member)
                 .post(post)
+                .batchLikes(post.getBatchLikes())
                 .build();
     }
 
@@ -47,6 +52,7 @@ public class Likes {
         return Likes.builder()
                 .member(member)
                 .academy(academy)
+                .batchLikes(academy.getBatchLikes())
                 .build();
     }
 
@@ -54,6 +60,7 @@ public class Likes {
         return Likes.builder()
                 .member(member)
                 .tutorInfo(tutorInfo)
+                .batchLikes(tutorInfo.getBatchLikes())
                 .build();
     }
 }

--- a/src/main/java/project/academyshow/entity/Post.java
+++ b/src/main/java/project/academyshow/entity/Post.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -37,6 +38,9 @@ public class Post extends AbstractTimestampEntity {
     @JoinColumn(name = "tutor_info_id")
     private TutorInfo tutorInfo;
 
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private List<BatchLikes> batchLikes;
+
     public String profileOfAcademy() {
         return academy.getProfile();
     }
@@ -51,5 +55,9 @@ public class Post extends AbstractTimestampEntity {
 
     public String nameOfMember() {
         return member.getName();
+    }
+
+    public BatchLikes getBatchLikes() {
+        return batchLikes.get(0);
     }
 }

--- a/src/main/java/project/academyshow/entity/TutorInfo.java
+++ b/src/main/java/project/academyshow/entity/TutorInfo.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Builder
@@ -41,4 +42,11 @@ public class TutorInfo {
     private String area;
 
     private String phone;
+
+    @OneToMany(mappedBy = "tutorInfo", fetch = FetchType.LAZY)
+    private List<BatchLikes> batchLikes;
+
+    public BatchLikes getBatchLikes() {
+        return batchLikes.get(0);
+    }
 }

--- a/src/main/java/project/academyshow/repository/BatchLikesRepository.java
+++ b/src/main/java/project/academyshow/repository/BatchLikesRepository.java
@@ -1,0 +1,7 @@
+package project.academyshow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.academyshow.entity.BatchLikes;
+
+public interface BatchLikesRepository extends JpaRepository<BatchLikes, Long> {
+}

--- a/src/main/java/project/academyshow/service/AuthService.java
+++ b/src/main/java/project/academyshow/service/AuthService.java
@@ -16,10 +16,7 @@ import project.academyshow.controller.request.LoginRequest;
 import project.academyshow.controller.request.TutorRequest;
 import project.academyshow.controller.request.UserSignUpRequest;
 import project.academyshow.entity.*;
-import project.academyshow.repository.AcademyRepository;
-import project.academyshow.repository.MemberRepository;
-import project.academyshow.repository.RefreshTokenRepository;
-import project.academyshow.repository.TutorInfoRepository;
+import project.academyshow.repository.*;
 import project.academyshow.security.entity.CustomUserDetails;
 import project.academyshow.security.token.Token;
 import project.academyshow.security.token.TokenProvider;
@@ -49,6 +46,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final AcademyRepository academyRepository;
     private final TutorInfoRepository tutorInfoRepository;
+    private final BatchLikesRepository batchLikesRepository;
     private final static long THREE_DAYS_IN_MILLISECONDS = 259200000;
 
     /** 일반 회원가입 */
@@ -61,7 +59,9 @@ public class AuthService {
         /* 회원 기본 정보 */
         Member savedMember = memberRepository.save(userInfo.toEntity(passwordEncoder, RoleType.ROLE_ACADEMY));
         /* 학원 정보 */
-        academyRepository.save(academyInfo.toEntity(savedMember));
+        Academy academy = academyRepository.save(academyInfo.toEntity(savedMember));
+        /* 배치 좋아요 정보*/
+        batchLikesRepository.save(BatchLikes.of(academy));
     }
 
     /** 과외 회원가입 */
@@ -69,7 +69,9 @@ public class AuthService {
         /* 회원 기본 정보 */
         Member savedMember = memberRepository.save(userInfo.toEntity(passwordEncoder, RoleType.ROLE_TUTOR));
         /* 과외 정보 */
-        tutorInfoRepository.save(tutorRequest.toEntity(savedMember));
+        TutorInfo tutorInfo = tutorInfoRepository.save(tutorRequest.toEntity(savedMember));
+        /* 배치 좋아요 정보*/
+        batchLikesRepository.save(BatchLikes.of(tutorInfo));
     }
 
     /** username 중복 확인 */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,12 @@ spring:
     restart:
       enabled: true
 
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: never
+
 logging.level:
   project.academyshow: debug
   org.hibernate.SQL: debug


### PR DESCRIPTION
## Description
- BatchLikes 엔티티추가
- Spring batch 기반의 BatchLikes 배치작업 및 Spring 스케줄러 설정 (하루마다 정기적으로 집계)

## 배치작업을 시키는 이유
- 사용자가 적은 시간때 배치작업을 해서 자원효율성 높일수 있다.

## Spring Batch 도입이유
- 페이징을 통해 n개씩 가져와 처리하는것이 가능하다. 따라서 데이터가 많을때 `outofmemoryerror`을 예방할수 있다.
- 실패시 재시작 기능을 제공한다

## BatchLikes에 @Onetomany, @manytoone 을 사용하는이유
- onetoone의 경우 공부해본결과 주인이 아닌테이블에서 lazy loading을 사용할수 없다. JPA에서 주인이 아닌 테이블의 경우 왜래키 컬럼이 없으므로 이를 NULL로 처리할지 프록시로 처리할지 알수 없기 때문에, JPQL 사용시 무조건 쿼리를 날리게 된다. 이는 N+1 문제를 야기할 위험이 있다.
- 따라서 onetoone 의 사용을 지양하는 래퍼런스 자료가 많았다.
