### PR TITLE
Post 응답에 좋아요 개수 정보 추가

### DIFF
--- a/src/main/java/project/academyshow/controller/AcademyController.java
+++ b/src/main/java/project/academyshow/controller/AcademyController.java
@@ -106,7 +106,8 @@ public class AcademyController {
     }
 
     @GetMapping("/academy/{id}/posts")
-    public ApiResponse<?> findAllPosts(@PathVariable("id") Long id, Pageable pageable) {
-        return ApiResponse.success(postService.findAllByAcademy(id, pageable).map(PostResponse::ofList));
+    public ApiResponse<?> findAllPosts(@PathVariable("id") Long id,
+                                       Pageable pageable) {
+        return ApiResponse.success(postService.findAllByAcademy(id, pageable));
     }
 }

--- a/src/main/java/project/academyshow/controller/PostController.java
+++ b/src/main/java/project/academyshow/controller/PostController.java
@@ -27,14 +27,14 @@ public class PostController {
     }
 
     @GetMapping("/posts/{id}")
-    public ApiResponse<?> findById(@PathVariable Long id) {
-        return ApiResponse.success(PostResponse.of(postService.findById(id)));
+    public ApiResponse<?> findById(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                   @PathVariable Long id) {
+        return ApiResponse.success(postService.findById(id, userDetails));
     }
 
     @GetMapping("/posts")
-    public ApiResponse<?> findAll(PostCategory category, Pageable pageable) {
-        return ApiResponse.success(
-                postService.findAllByCategory(category, pageable)
-                .map(PostResponse::of));
+    public ApiResponse<?> findAll(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                  Pageable pageable) {
+        return ApiResponse.success(postService.findAll(pageable));
     }
 }

--- a/src/main/java/project/academyshow/controller/TutorInfoController.java
+++ b/src/main/java/project/academyshow/controller/TutorInfoController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 import project.academyshow.controller.request.ReviewRequest;
 import project.academyshow.controller.request.SearchRequest;
 import project.academyshow.controller.response.ApiResponse;
-import project.academyshow.controller.response.PostResponse;
 import project.academyshow.controller.response.ReferenceLikesStatistics;
 import project.academyshow.controller.response.ReviewStatistics;
 import project.academyshow.entity.ReferenceType;
@@ -79,8 +78,9 @@ public class TutorInfoController {
     }
 
     @GetMapping("/tutor/{id}/posts")
-    public ApiResponse<?> findAllPosts(@PathVariable("id") Long id, Pageable pageable) {
-        return ApiResponse.success(postService.findAllByTutorInfo(id, pageable).map(PostResponse::ofList));
+    public ApiResponse<?> findAllPosts(@PathVariable("id") Long id,
+                                       Pageable pageable) {
+        return ApiResponse.success(postService.findAllByTutorInfo(id, pageable));
     }
 
 

--- a/src/main/java/project/academyshow/controller/request/AcademyInfo.java
+++ b/src/main/java/project/academyshow/controller/request/AcademyInfo.java
@@ -3,6 +3,7 @@ package project.academyshow.controller.request;
 import lombok.Data;
 import org.springframework.util.StringUtils;
 import project.academyshow.entity.Academy;
+import project.academyshow.entity.BatchLikes;
 import project.academyshow.entity.Member;
 import project.academyshow.entity.Subject;
 
@@ -27,7 +28,7 @@ public class AcademyInfo {
     private String profile;
     private String phone;
 
-    public Academy toEntity(Member savedMember) {
+    public Academy toEntity(Member savedMember, BatchLikes batchLikes) {
         if (!StringUtils.hasText(profile)) profile = null;
 
         String educations = String.join(",", this.educations);
@@ -51,6 +52,7 @@ public class AcademyInfo {
                 .subjects(subjects)
                 .profile(profile)
                 .phone(phone)
+                .batchLikes(batchLikes)
                 .build();
     }
 }

--- a/src/main/java/project/academyshow/controller/request/TutorRequest.java
+++ b/src/main/java/project/academyshow/controller/request/TutorRequest.java
@@ -1,6 +1,7 @@
 package project.academyshow.controller.request;
 
 import lombok.Data;
+import project.academyshow.entity.BatchLikes;
 import project.academyshow.entity.Member;
 import project.academyshow.entity.Subject;
 import project.academyshow.entity.TutorInfo;
@@ -16,7 +17,7 @@ public class TutorRequest {
     private String certification;
     private String phone;
 
-    public TutorInfo toEntity(Member member) {
+    public TutorInfo toEntity(Member member, BatchLikes batchLikes) {
         String educations = String.join(",", this.educations);
 
         String subjects = this.subjects.stream()
@@ -30,6 +31,7 @@ public class TutorRequest {
                 .educations(educations)
                 .subjects(subjects)
                 .phone(phone)
+                .batchLikes(batchLikes)
                 .build();
     }
 }

--- a/src/main/java/project/academyshow/controller/response/PostResponse.java
+++ b/src/main/java/project/academyshow/controller/response/PostResponse.java
@@ -3,6 +3,7 @@ package project.academyshow.controller.response;
 import lombok.Getter;
 import project.academyshow.entity.*;
 
+
 @Getter
 public class PostResponse extends AbstractAcademyshowResponse{
     private Long id;
@@ -10,8 +11,9 @@ public class PostResponse extends AbstractAcademyshowResponse{
     private String title;
     private String content;
     private String profile;
+    private ReferenceLikesStatistics likes;
 
-    private PostResponse(Post post) {
+    private PostResponse(Post post, ReferenceLikesStatistics likes) {
         super(post);
         this.id = post.getId();
         this.nickname = post.getMember().getName();
@@ -20,14 +22,26 @@ public class PostResponse extends AbstractAcademyshowResponse{
                 post.getCategory() == PostCategory.ACADEMY_NEWS ? post.profileOfAcademy() : post.profileOfMember();
         this.nickname =
                 post.getCategory() == PostCategory.ACADEMY_NEWS ? post.nameOfAcademy() : post.nameOfMember();
-    }
-    
-    public static PostResponse ofList(Post post) {
-        return new PostResponse(post);
+        this.likes = likes;
     }
 
-    public static PostResponse of(Post post) {
-        PostResponse response =  new PostResponse(post);
+    public static PostResponse ofList(Post post, BatchLikes batchLikes) {
+        return new PostResponse(post, ReferenceLikesStatistics.notAuthenticatedOf(batchLikes.getCount()));
+    }
+
+    public static PostResponse ofAuthenticatedListRequest(Post post, BatchLikes batchLikes, boolean isLike) {
+        return new PostResponse(post, ReferenceLikesStatistics.of(batchLikes.getCount(), isLike));
+    }
+
+    public static PostResponse of(Post post, BatchLikes batchLikes) {
+        PostResponse response = new PostResponse(
+                post, ReferenceLikesStatistics.notAuthenticatedOf(batchLikes.getCount()));
+        response.content = post.getContent();
+        return response;
+    }
+
+    public static PostResponse ofAuthenticatedRequest(Post post, BatchLikes batchLikes, boolean isLike) {
+        PostResponse response = new PostResponse(post, ReferenceLikesStatistics.of(batchLikes.getCount(), isLike));
         response.content = post.getContent();
         return response;
     }

--- a/src/main/java/project/academyshow/dev/database/DbInit.java
+++ b/src/main/java/project/academyshow/dev/database/DbInit.java
@@ -30,8 +30,8 @@ public class DbInit {
         exampleInsert.insertAcademyMemberAndAcademy();
         exampleInsert.insertTutorMemberAndTutorInfo();
         exampleInsert.insertAcademyReview();
-        exampleInsert.insertUp();
         exampleInsert.insertAcademyNews();
+        exampleInsert.insertUp();
     }
 
     @Component
@@ -46,6 +46,7 @@ public class DbInit {
         private final List<Member> academyMembers = new ArrayList<>();
         private final List<Member> tutorMembers = new ArrayList<>();
         private final List<Academy> academies = new ArrayList<>();
+        private final List<Post> posts = new ArrayList<>();
 
         /** 과목 데이터 */
         public void insertSubject() {
@@ -258,8 +259,9 @@ public class DbInit {
             );
         }
 
-        /** 학원 데이터 */
+
         public void insertUp() {
+            /** 학원 데이터 */
             createUp(ReferenceType.ACADEMY, academies.get(0).getId(), normalMembers.get(0));
             createUp(ReferenceType.ACADEMY, academies.get(0).getId(), normalMembers.get(1));
             createUp(ReferenceType.ACADEMY, academies.get(1).getId(), normalMembers.get(1));
@@ -274,6 +276,22 @@ public class DbInit {
             createUp(ReferenceType.ACADEMY, academies.get(0).getId(), tutorMembers.get(0));
             createUp(ReferenceType.ACADEMY, academies.get(1).getId(), tutorMembers.get(0));
             createUp(ReferenceType.ACADEMY, academies.get(2).getId(), tutorMembers.get(0));
+
+            /** post(게시물) 데이터 */
+            createUp(ReferenceType.POST, posts.get(0).getId(), normalMembers.get(0));
+            createUp(ReferenceType.POST, posts.get(0).getId(), normalMembers.get(1));
+            createUp(ReferenceType.POST, posts.get(1).getId(), normalMembers.get(1));
+            createUp(ReferenceType.POST, posts.get(2).getId(), normalMembers.get(2));
+            createUp(ReferenceType.POST, posts.get(2).getId(), normalMembers.get(3));
+            createUp(ReferenceType.POST, posts.get(0).getId(), academyMembers.get(0));
+            createUp(ReferenceType.POST, posts.get(1).getId(), academyMembers.get(1));
+            createUp(ReferenceType.POST, posts.get(2).getId(), academyMembers.get(2));
+            createUp(ReferenceType.POST, posts.get(3).getId(), academyMembers.get(3));
+            createUp(ReferenceType.POST, posts.get(4).getId(), academyMembers.get(4));
+            createUp(ReferenceType.POST, posts.get(5).getId(), academyMembers.get(5));
+            createUp(ReferenceType.POST, posts.get(0).getId(), tutorMembers.get(0));
+            createUp(ReferenceType.POST, posts.get(1).getId(), tutorMembers.get(0));
+            createUp(ReferenceType.POST, posts.get(2).getId(), tutorMembers.get(0));
         }
 
         /** 학원 소식 데이터 */
@@ -299,6 +317,9 @@ public class DbInit {
         /** ==================================================================================================== */
 
         private void createAcademyNews(Academy academy, String title, String content) {
+            BatchLikes batchLikes = new BatchLikes();
+            em.persist(batchLikes);
+
             Post post = Post.builder()
                     .academy(academy)
                     .member(academy.getMember())
@@ -306,10 +327,11 @@ public class DbInit {
                     .content(content)
                     .category(PostCategory.ACADEMY_NEWS)
                     .tutorInfo(null)
+                    .batchLikes(batchLikes)
                     .build();
 
             em.persist(post);
-            em.persist(BatchLikes.of(post));
+            posts.add(post);
         }
 
         private void createUp(ReferenceType type, Long referenceId, Member member) {
@@ -344,6 +366,9 @@ public class DbInit {
         }
 
         private void createTutorInfo(Member member, String[] info) {
+            BatchLikes batchLikes = new BatchLikes();
+            em.persist(batchLikes);
+
             TutorInfo tutorInfo = TutorInfo.builder()
                     .member(member)
                     .scholarship(info[0])
@@ -355,13 +380,16 @@ public class DbInit {
                     .area(info[5])
                     .isExposed(true)
                     .phone(info[6])
+                    .batchLikes(batchLikes)
                     .build();
 
             em.persist(tutorInfo);
-            em.persist(BatchLikes.of(tutorInfo));
         }
 
         private void createAcademy(Member member, String[] academyInfo) {
+            BatchLikes batchLikes = new BatchLikes();
+            em.persist(batchLikes);
+
             Academy academy = Academy.builder()
                     .member(member)
                     .businessRegistration("사업자등록증 파일 경로")
@@ -376,10 +404,10 @@ public class DbInit {
                     .subjects(academyInfo[6])
                     .profile(academyInfo[7])
                     .phone(academyInfo[8])
+                    .batchLikes(batchLikes)
                     .build();
 
             em.persist(academy);
-            em.persist(BatchLikes.of(academy));
             academies.add(academy);
         }
 

--- a/src/main/java/project/academyshow/entity/Academy.java
+++ b/src/main/java/project/academyshow/entity/Academy.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.List;
 
 @Entity
 @Builder
@@ -44,10 +43,11 @@ public class Academy {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "academy", fetch = FetchType.LAZY)
-    private List<BatchLikes> batchLikes;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_likes_id")
+    private BatchLikes batchLikes;
 
     public BatchLikes getBatchLikes() {
-        return batchLikes.get(0);
+        return batchLikes;
     }
 }

--- a/src/main/java/project/academyshow/entity/Academy.java
+++ b/src/main/java/project/academyshow/entity/Academy.java
@@ -39,7 +39,7 @@ public class Academy {
 
     private String phone;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/project/academyshow/entity/BatchLikes.java
+++ b/src/main/java/project/academyshow/entity/BatchLikes.java
@@ -18,44 +18,11 @@ public class BatchLikes {
     @Column
     private Long count = 0L;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "academy_id")
-    private Academy academy;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tutor_info_id")
-    private TutorInfo tutorInfo;
-
     public void resetCountForBatch() {
         this.count = 0L;
     }
 
     public void incrementCountForBatch() {
         this.count += 1L;
-    }
-
-    /**
-     * batchlikes creator
-     */
-    public static BatchLikes of(Post post) {
-        return BatchLikes.builder()
-                .post(post)
-                .build();
-    }
-
-    public static BatchLikes of(Academy academy) {
-        return BatchLikes.builder()
-                .academy(academy)
-                .build();
-    }
-
-    public static BatchLikes of(TutorInfo tutorInfo) {
-        return BatchLikes.builder()
-                .tutorInfo(tutorInfo)
-                .build();
     }
 }

--- a/src/main/java/project/academyshow/entity/Member.java
+++ b/src/main/java/project/academyshow/entity/Member.java
@@ -6,6 +6,7 @@ import project.academyshow.controller.request.MyInfo;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @Builder
@@ -39,11 +40,11 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
-    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
-    private Academy academy;
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    private List<Academy> academy;
 
-    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
-    private TutorInfo tutorInfo;
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    private List<TutorInfo> tutorInfo;
 
     /** 내 정보 수정 */
     public void updateMember(MyInfo myInfo) {
@@ -56,5 +57,13 @@ public class Member {
         this.subAddress = myInfo.getSubAddress();
         this.selectRoadAddress = myInfo.isSelectRoadAddress();
         this.profile = myInfo.getProfile();
+    }
+
+    public Academy getAcademy() {
+        return academy.get(0);
+    }
+
+    public TutorInfo getTutorInfo() {
+        return tutorInfo.get(0);
     }
 }

--- a/src/main/java/project/academyshow/entity/Post.java
+++ b/src/main/java/project/academyshow/entity/Post.java
@@ -18,7 +18,7 @@ public class Post extends AbstractTimestampEntity {
     @Id @GeneratedValue
     private Long id;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/project/academyshow/entity/Post.java
+++ b/src/main/java/project/academyshow/entity/Post.java
@@ -38,8 +38,9 @@ public class Post extends AbstractTimestampEntity {
     @JoinColumn(name = "tutor_info_id")
     private TutorInfo tutorInfo;
 
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
-    private List<BatchLikes> batchLikes;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_likes_id")
+    private BatchLikes batchLikes;
 
     public String profileOfAcademy() {
         return academy.getProfile();
@@ -55,9 +56,5 @@ public class Post extends AbstractTimestampEntity {
 
     public String nameOfMember() {
         return member.getName();
-    }
-
-    public BatchLikes getBatchLikes() {
-        return batchLikes.get(0);
     }
 }

--- a/src/main/java/project/academyshow/entity/TutorInfo.java
+++ b/src/main/java/project/academyshow/entity/TutorInfo.java
@@ -43,10 +43,11 @@ public class TutorInfo {
 
     private String phone;
 
-    @OneToMany(mappedBy = "tutorInfo", fetch = FetchType.LAZY)
-    private List<BatchLikes> batchLikes;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_likes_id")
+    private BatchLikes batchLikes;
 
     public BatchLikes getBatchLikes() {
-        return batchLikes.get(0);
+        return batchLikes;
     }
 }

--- a/src/main/java/project/academyshow/entity/TutorInfo.java
+++ b/src/main/java/project/academyshow/entity/TutorInfo.java
@@ -31,7 +31,7 @@ public class TutorInfo {
 
     private String introduce;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/project/academyshow/repository/PostRepository.java
+++ b/src/main/java/project/academyshow/repository/PostRepository.java
@@ -4,34 +4,46 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import project.academyshow.entity.Member;
 import project.academyshow.entity.Post;
 import project.academyshow.entity.PostCategory;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-//    @Query(
-//            value = "select p " +
-//                    "from Post p " +
-//                    "inner join fetch p.member " +
-//                    "inner join fetch p.academy " +
-//                    "where p.category = #{postRequest.category}",
-//
-//            countQuery = "select p " +
-//                         "from Post p " +
-//                         "where p.category = #{postRequest.category}"
-//    )
-//    Page<Post> findAll(PostRequest postRequest, Pageable pageable);
+    /**
+     * 여러 post를 조회한다.
+     * @param pageable
+     * @return
+     */
+    @Query(
+            value = "select p " +
+                    "from Post p " +
+                    "inner join fetch p.batchLikes " +
+                    "inner join fetch p.member " +
+                    "left join fetch p.academy " +
+                    "left join fetch p.tutorInfo ",
+
+            countQuery = "select count(p) " +
+                    "from Post p "
+    )
+    Page<Post> findAll(Pageable pageable);
+
+    @Query("select l.post " +
+            "from Likes l " +
+            "where l.post = :post " +
+            "and l.member = :member")
+    Post likedByMemberAndInPost(Member member, Post post);
 
     @Query("select p " +
             "from Post p " +
             "where p.academy.id = :id " +
             "order by p.createdAt desc")
-    Page<Post> findAllByAcademy(Long id, Pageable pageable);
+    Page<Post> findAllByAcademyId(Long id, Pageable pageable);
 
     @Query("select p " +
             "from Post p " +
             "where p.tutorInfo.id = :id " +
             "order by p.createdAt desc")
-    Page<Post> findAllByTutorInfo(Long id, Pageable pageable);
+    Page<Post> findAllByTutorInfoId(Long id, Pageable pageable);
 
     Page<Post> findAllByCategoryOrderByCreatedAtDesc(PostCategory category, Pageable pageable);
 

--- a/src/main/java/project/academyshow/service/AuthService.java
+++ b/src/main/java/project/academyshow/service/AuthService.java
@@ -58,20 +58,21 @@ public class AuthService {
     public void academySignUp(UserSignUpRequest userInfo, AcademyInfo academyInfo) {
         /* 회원 기본 정보 */
         Member savedMember = memberRepository.save(userInfo.toEntity(passwordEncoder, RoleType.ROLE_ACADEMY));
+
+        BatchLikes batchLikes = batchLikesRepository.save(new BatchLikes());
+
         /* 학원 정보 */
-        Academy academy = academyRepository.save(academyInfo.toEntity(savedMember));
-        /* 배치 좋아요 정보*/
-        batchLikesRepository.save(BatchLikes.of(academy));
+        Academy academy = academyRepository.save(academyInfo.toEntity(savedMember, batchLikes));
     }
 
     /** 과외 회원가입 */
     public void tutorSignUp(UserSignUpRequest userInfo, TutorRequest tutorRequest) {
         /* 회원 기본 정보 */
         Member savedMember = memberRepository.save(userInfo.toEntity(passwordEncoder, RoleType.ROLE_TUTOR));
+
+        BatchLikes batchLikes = batchLikesRepository.save(new BatchLikes());
         /* 과외 정보 */
-        TutorInfo tutorInfo = tutorInfoRepository.save(tutorRequest.toEntity(savedMember));
-        /* 배치 좋아요 정보*/
-        batchLikesRepository.save(BatchLikes.of(tutorInfo));
+        TutorInfo tutorInfo = tutorInfoRepository.save(tutorRequest.toEntity(savedMember, batchLikes));
     }
 
     /** username 중복 확인 */


### PR DESCRIPTION
## New Features
- BatchLikes 정보를 활용하여 Post응답에 좋아요 갯수 정보 추가
- Post응답을 정렬해서 반환하는 기능 추가
    ```
    # 좋아요가 가장 많은 순서로 10개의 post를 반환
     /api/posts?size=10&sort=batchLikes.count,desc
    ```
     - 정렬 기능을 위해 post 대 batchLikes의 관계를 oneToMany에서 manyToOne으로 변경

## 풀리퀘스트 반영후 application-dev.yml 수정필요
```
spring:
...
  batch:
    job:
      enabled: false
    jdbc:
      initialize-schema: always
```
## 관련 프론트 풀리퀘스트 #10 
